### PR TITLE
Resolves #114, データ自動更新 GitHub Actions の追加

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -1,4 +1,4 @@
-name: covid19 updater
+name: update json data
 on:
   # push:
   #   paths:
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout covid19-scraping
       uses: actions/checkout@v2
       with:
-        repository:  stop-covid19-hyogo/covid19-scraping
+        repository: stop-covid19-hyogo/covid19-scraping
         ref: 'gh-pages'
         path: 'covid19-scraping'
 
@@ -37,7 +37,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add data
-        git commit -m "Add changes `date '+%Y-%m-%dT%H:%M:%SZ'`"
+        git commit -m "update json data `date '+%Y-%m-%dT%H:%M:%SZ'`"
 
     - name: Push changes
       continue-on-error: true

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -1,0 +1,47 @@
+name: covid19 updater
+on:
+  # push:
+  #   paths:
+  #     - '.github/workflows/update_data.yml'
+  # pull_request:
+  #   paths:
+  #     - '.github/workflows/update_data.yml'
+  schedule:
+    - cron:  '15 21 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout covid19
+      uses: actions/checkout@v2
+      with:
+        ref: 'development'
+
+    - name: Checkout covid19-scraping
+      uses: actions/checkout@v2
+      with:
+        repository:  stop-covid19-hyogo/covid19-scraping
+        ref: 'gh-pages'
+        path: 'covid19-scraping'
+
+    - name: copy files
+      run: cp -p covid19-scraping/*.json data
+
+    - run: git diff
+
+    - name: Commit files
+      continue-on-error: true
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add data
+        git commit -m "Add changes `date '+%Y-%m-%dT%H:%M:%SZ'`"
+
+    - name: Push changes
+      continue-on-error: true
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: 'development'

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -7,7 +7,7 @@ on:
   #   paths:
   #     - '.github/workflows/update_data.yml'
   schedule:
-    - cron:  '15 21 * * *'
+    - cron:  '15 12 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #114 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- データ自動更新 GitHub Actions の追加
- stop-covid19-hyogo/covid19-scraping より JSON ファイルを取得し、 development ブランチに push する
   - 毎日21時15分に実行する
   - データ更新の無い場合は更新しない(コミットがエラーになるが、無視される)

## 実行サンプル

https://github.com/nanasess/covid19-hyogo/runs/518810837?check_suite_focus=true

## その他
ローカルでテストする際は、[on.push 以下のコメント](https://github.com/nanasess/covid19-hyogo/blob/improve/updater/.github/workflows/update_data.yml#L3-L8) を外してください。 `<フォーク先>/covid19` の development ブランチに push されます
