### PR TITLE
add "入院患者数と残り病床数" and  change table of "クラスター別陽性患者数" to graph

### DIFF
--- a/components/CircleChart.vue
+++ b/components/CircleChart.vue
@@ -1,0 +1,152 @@
+<template>
+  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+    <template v-slot:button>
+      <p class="Graph-Desc">
+        （注）病床数は兵庫県が公開する
+        <a
+          class="link"
+          href="https://web.pref.hyogo.lg.jp/kk03/documents/corona-200319.pdf"
+          target="_blank"
+          rel="noopener">PDF</a>を参照
+      </p>
+    </template>
+    <pie-chart
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="displayOption"
+      :height="240"
+    />
+    <template v-slot:infoPanel>
+      <data-view-basic-info-panel
+        :l-text="displayInfo.lText"
+        :s-text="displayInfo.sText"
+        :unit="displayInfo.unit"
+      />
+    </template>
+  </data-view>
+</template>
+
+<script>
+import DataView from '@/components/DataView.vue'
+import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+
+export default {
+  components: { DataView, DataViewBasicInfoPanel },
+  props: {
+    title: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    titleId: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    chartId: {
+      type: String,
+      required: false,
+      default: 'pie-chart'
+    },
+    chartData: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+    date: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    unit: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    info: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    url: {
+      type: String,
+      required: false,
+      default: ''
+    }
+  },
+  computed: {
+    displayInfo() {
+      return {
+        lText: this.chartData[
+          this.chartData.length - 1
+        ].cumulative.toLocaleString(),
+        sText: this.info,
+        unit: this.unit
+      }
+    },
+    displayData() {
+      const colorArray = ['#46B5D0', '#979797']
+      return {
+        labels: this.chartData.map(d => {
+          return d.label
+        }),
+        datasets: [
+          {
+            label: this.chartData.map(d => {
+              return d.label
+            }),
+            data: this.chartData.map(d => {
+              return d.transition
+            }),
+            backgroundColor: this.chartData.map((d, index) => {
+              return colorArray[index]
+            }),
+            borderWidth: 0
+          }
+        ]
+      }
+    },
+    displayOption() {
+      const unit = this.unit
+      const chartData = this.chartData
+      return {
+        tooltips: {
+          displayColors: false,
+          callbacks: {
+            label(tooltipItem) {
+              /* return (
+                parseInt(
+                  chartData[tooltipItem.index].transition
+                ).toLocaleString() + unit
+              ) */
+              return `${chartData[tooltipItem.index].transition} ${
+                tooltipItem.index === 1 ? unit : '人'
+              } (総病床数: ${chartData[0].transition +
+                chartData[1].transition}${unit})`
+            },
+            title(tooltipItem, data) {
+              return data.labels[tooltipItem[0].index]
+            }
+          }
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+        legend: {
+          display: true
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.Graph-Desc {
+  margin: 10px 0;
+  font-size: 12px;
+  color: $gray-3;
+}
+.link {
+  text-decoration: none;
+}
+</stylela>

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,9 +1,25 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date" :url="url">
     <template v-if="showButton === true" v-slot:button>
+      <p class="Graph-Desc">
+        {{ desc }}
+      </p>
       <data-selector v-model="dataKind" />
     </template>
+    <template v-else v-slot:button>
+      <p class="Graph-Desc">
+        {{ desc }}
+      </p>
+    </template>
+    <horizontal-bar
+      v-if="horizontal === true"
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="displayOption"
+      :height="240"
+    />
     <bar
+      v-else
       :chart-id="chartId"
       :chart-data="displayData"
       :options="displayOption"
@@ -18,8 +34,6 @@
     </template>
   </data-view>
 </template>
-
-<style></style>
 
 <script>
 import DataView from '@/components/DataView.vue'
@@ -64,10 +78,25 @@ export default {
       required: false,
       default: ''
     },
+    desc: {
+      type: String,
+      required: false,
+      default: ''
+    },
     showButton: {
       type: Boolean,
       required: false,
       default: true
+    },
+    horizontal: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    overlap: {
+      type: Number,
+      required: false,
+      default: 0
     }
   },
   data() {
@@ -94,6 +123,9 @@ export default {
             : this.chartData[this.chartData.length - 1].cumulative.toLocaleString(),
           sText: this.showButton
             ? `実績値（前日比：${this.displayTransitionRatio} ${this.unit}）`
+            : this.overlap
+            ? `重複者: ${this.chartData[this.chartData.length - 1].cumulative -
+                this.overlap}${this.unit}`
             : ``,
           unit: this.unit
         }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -62,8 +62,8 @@
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="年代別陽性患者数"
-          :title-id="'number-of-confirmed-cases'"
-          :chart-id="'time-bar-chart-patients'"
+          :title-id="'patients-by-age'"
+          :chart-id="'time-bar-chart-patients-by-age'"
           :chart-data="ageGraph"
           :date="age.last_update"
           :unit="'人'"
@@ -72,15 +72,39 @@
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
-        <data-table
+        <!--<data-table
           :title="'クラスター別陽性患者数'"
-          :title-id="'attributes-of-confirmed-cases'"
+          :title-id="'patients-by-clusters'"
           :chart-data="clustersTable"
           :chart-option="{}"
           :date="clustersSummary.last_update"
           :info="sumInfoOfPatients"
           :url="'https://web.pref.hyogo.lg.jp/kk03/corona_hasseijyokyo.html'"
           :desc="'（注）同一の対象者が複数含まれる場合あり'"
+        />-->
+        <time-bar-chart
+          title="クラスター別陽性患者数"
+          :title-id="'patients-by-clusters'"
+          :chart-id="'time-bar-chart-patients-by-clusters'"
+          :chart-data="clustersGraph"
+          :date="clustersSummary.last_update"
+          :unit="'人'"
+          :url="'https://web.pref.hyogo.lg.jp/kk03/corona_hasseijyokyo.html'"
+          :desc="'（注）同一の対象者が複数含まれる場合あり'"
+          :show-button="false"
+          :horizontal="true"
+          :overlap="patientsTable.datasets.length"
+        />
+      </v-col>
+      <v-col cols="12" md="6" class="DataCard">
+        <circle-chart
+          title="入院患者数と残り病床数"
+          :title-id="'patients-and-sickbeds'"
+          :chart-data="sickbedsGraph"
+          :date="sickbedsSummary.last_update"
+          :unit="'床'"
+          :info="'総病床数'"
+          :url="'https://web.pref.hyogo.lg.jp/kk03/corona_hasseijyokyo.html'"
         />
       </v-col>
     </v-row>
@@ -91,6 +115,7 @@
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
 import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
+import CircleChart from '@/components/CircleChart'
 import lastUpdate from '@/data/last_update.json'
 import patients from '@/data/patients.json'
 import patientsSummary from '@/data/patients_summary.json'
@@ -99,12 +124,13 @@ import dischargesSummary from '@/data/discharges_summary.json'
 import inspectionsSummary from '@/data/inspections_summary.json'
 import age from '@/data/age.json'
 import clustersSummary from '@/data/clusters_summary.json'
+import sickbedsSummary from '@/data/sickbeds_summary.json'
 import DataTable from '@/components/DataTable.vue'
 import formatGraph from '@/utils/formatGraph'
 import formatTable from '@/utils/formatTable'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
 import formatVariableGraph from '@/utils/formatVariableGraph'
-import formatClustersTable from '@/utils/formatClustersTable'
+// import formatClustersTable from '@/utils/formatClustersTable'
 import News from '@/data/news.json'
 import SvgCard from '@/components/SvgCard.vue'
 import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
@@ -114,6 +140,7 @@ export default {
     PageHeader,
     TimeBarChart,
     TimeStackedBarChart,
+    CircleChart,
     DataTable,
     SvgCard,
     ConfirmedCasesTable
@@ -148,7 +175,11 @@ export default {
     const ageGraph = formatVariableGraph(age.data)
 
     // クラスター別陽性患者数
-    const clustersTable = formatClustersTable(clustersSummary.data)
+    //const clustersTable = formatClustersTable(clustersSummary.data)
+    const clustersGraph = formatVariableGraph(clustersSummary.data)
+
+    // 入院患者数と残り病床数
+    const sickbedsGraph = formatVariableGraph(sickbedsSummary.data)
 
     // 死亡者数
     // #MEMO: 今後使う可能性あるので一時コメントアウト
@@ -171,6 +202,7 @@ export default {
       inspectionsSummary,
       age,
       clustersSummary,
+      sickbedsSummary,
       patientsTable,
       patientsGraph,
       dischargesGraph,
@@ -178,7 +210,9 @@ export default {
       inspectionsItems,
       inspectionsLabels,
       ageGraph,
-      clustersTable,
+      // clustersTable,
+      clustersGraph,
+      sickbedsGraph,
       confirmedCases,
       sumInfoOfPatients,
       headerItem: {

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -1,6 +1,6 @@
 import Vue, { PropType } from 'vue'
 import { ChartData, ChartOptions } from 'chart.js'
-import { Doughnut, Bar, mixins } from 'vue-chartjs'
+import { Doughnut, Pie, Bar, HorizontalBar, mixins } from 'vue-chartjs'
 import { Plugin } from '@nuxt/types'
 
 type ChartVCData = { chartData: ChartData }
@@ -31,9 +31,43 @@ const VueChartPlugin: Plugin = () => {
   )
 
   Vue.component<ChartVCData, ChartVCMethod, ChartVCComputed, ChartVCProps>(
+    'pie-chart',
+    {
+      extends: Pie,
+      mixins: [reactiveProp],
+      props: {
+        options: {
+          type: Object as PropType<ChartOptions>,
+          default: () => {}
+        }
+      },
+      mounted(): void {
+        this.renderChart(this.chartData, this.options)
+      }
+    }
+  )
+
+  Vue.component<ChartVCData, ChartVCMethod, ChartVCComputed, ChartVCProps>(
     'bar',
     {
       extends: Bar,
+      mixins: [reactiveProp],
+      props: {
+        options: {
+          type: Object,
+          default: () => {}
+        }
+      },
+      mounted(): void {
+        this.renderChart(this.chartData, this.options)
+      }
+    }
+  )
+
+  Vue.component<ChartVCData, ChartVCMethod, ChartVCComputed, ChartVCProps>(
+    'horizontal-bar',
+    {
+      extends: HorizontalBar,
       mixins: [reactiveProp],
       props: {
         options: {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #106 
- close #116 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- plugins/vue-chart.tsを円グラフ(パイグラフ)と横棒グラフの生成を可能にするよう追記
- #106 の表を可視化できるようにするために縦棒グラフでは説明が入りきらなくて重なったため、横棒グラフに変更して対処
- 円グラフを生成できるようにファイルを追加
- #116 の実装と、それ伴うデータファイル(sickbeds_summary.json)の追加

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34832037/77139824-d1877c00-6aba-11ea-8ea1-2627f63d5b75.png)
