### PR TITLE
知事メッセージの更新

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -142,7 +142,7 @@ export default {
         },
         {
           title: this.$t('Message from Governor Ido'),
-          link: 'https://web.pref.hyogo.lg.jp/governor/g_comment20200301.html',
+          link: 'https://web.pref.hyogo.lg.jp/governor/g_comment20200321.html',
           divider: true
         },
         {


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #155 

## ⛏ 変更内容 / Details of Changes
- 『知事からのメッセージ』のリンク先を3月1日更新の古いページから，3月21日更新の[新しいページ](https://web.pref.hyogo.lg.jp/governor/g_comment20200321.html)へ更新．