### PR TITLE
病床数の参照PDFのリンク切れを修正

### DIFF
--- a/components/CircleChart.vue
+++ b/components/CircleChart.vue
@@ -5,7 +5,7 @@
         （注）病床数は兵庫県が公開する
         <a
           class="link"
-          href="https://web.pref.hyogo.lg.jp/kk03/documents/corona200324-2-1.pdf"
+          href="https://web.pref.hyogo.lg.jp/kk03/documents/corona200324-2-1_1.pdf"
           target="_blank"
           rel="noopener"
         >PDF</a>を参照


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- #158

## ⛏ 変更内容 / Details of Changes
- 入院患者数と残り病床数の参照PDFのリンクが切れていたのを修正
- 現在有効な https://web.pref.hyogo.lg.jp/kk03/documents/corona200324-2-1_1.pdf にリンクを変更

## 📸 スクリーンショット / Screenshots
