### PR TITLE
add auto merge setting

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -46,4 +46,5 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         title: ${{ format('Update json data {0}', github.event.head_commit.timestamp) }}
+        labels: auto_merge
         branch-suffix: 'short-commit-hash'


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #202 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `auto-merge-bot` の導入
- 毎日21時に実行する json マージ用の PR 作成時に `auto_merge` ラベルを設定するよう修正
    - こうすることで `actions/labeler` を使用しなくてもよくなりました
