### PR TITLE
#52 JSON データの日付フォーマットを統一する

### DIFF
--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs'
 
 /**
- * Get datetime string formatted ISO8601(YYYY-MM-DDTHH:mm:ss)
+ * Get datetime string formatted ISO8601(YYYY-MM-DD HH:mm)
  *
  * @param dateString - Parsable string by dayjs
  */
 export const convertDatetimeToISO8601Format = (dateString: string): string => {
-  return dayjs(dateString).format('YYYY-MM-DDTHH:mm:ss')
+  return dayjs(dateString).format('YYYY-MM-DD HH:mm')
 }
 
 /**


### PR DESCRIPTION
#52について、Web側の日付フォーマットに関するユーティリティファイル(formatDate.ts)内の記述を'YYYY-MM-DDTHH:mm:ss'から'YYYY-MM-DD HH:mm'に変更しました。

なお、読み込むJSON側をYYYY-MM-DD HH:mm(或いはYYYY-MM-DD)とし、動作に問題ないことを確認しています。