### PR TITLE
change table of "クラスター別陽性患者数" to scatter chart

### DIFF
--- a/components/Scatter.vue
+++ b/components/Scatter.vue
@@ -1,0 +1,322 @@
+<template>
+  <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:description>
+      {{ desc }}
+    </template>
+    <scatter
+      :style="{ display: canvas ? 'block' : 'none' }"
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="displayOption"
+      :height="240"
+    />
+    <v-data-table
+      :style="{ top: '-9999px', position: canvas ? 'fixed' : 'static' }"
+      :headers="tableHeaders"
+      :items="tableData"
+      :items-per-page="-1"
+      :hide-default-footer="true"
+      :height="240"
+      :fixed-header="true"
+      :disable-sort="true"
+      :mobile-breakpoint="0"
+      class="cardTable"
+      item-key="name"
+    />
+    <template v-slot:infoPanel>
+      <data-view-basic-info-panel
+        :l-text="info.lText"
+        :s-text="info.sText"
+        :unit="info.unit"
+      />
+    </template>
+    <template v-slot:footer>
+      <open-data-link v-show="url" :url="url" />
+    </template>
+  </data-view>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+import {
+  GraphDataType,
+  ChildGraphDataType
+} from '@/utils/formatClustersScatter'
+import {
+  headers as TableHeader,
+  TableDataType
+} from '@/utils/formatClustersTable'
+import DataView from '@/components/DataView.vue'
+import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import OpenDataLink from '@/components/OpenDataLink.vue'
+
+import { single as color } from '@/utils/colors'
+
+type Data = {
+  dataKind: 'transition' | 'cumulative'
+  canvas: boolean
+}
+type Methods = {}
+type Computed = {
+  displayData: {
+    labels: string[]
+    datasets: {
+      fill: boolean
+      showLine: boolean
+      data: ChildGraphDataType[]
+      backgroundColor: string
+    }[]
+  }
+  displayOption: {
+    tooltips: {
+      displayColors: boolean
+      callbacks: {
+        label: (tooltipItem: any) => string
+        title: (tooltipItem: any, data: any) => string
+      }
+    }
+    responsive: boolean
+    maintainAspectRatio: boolean
+    legend: {
+      display: boolean
+    }
+    scales: object
+  }
+  tableHeaders: {
+    text: string
+    value: string
+  }[]
+  tableData: {
+    [key: number]: number
+  }[]
+}
+
+type Props = {
+  title: string
+  titleId: string
+  chartId: string
+  chartData: GraphDataType
+  date: string
+  unit: string
+  info: object
+  desc: string
+  url: string
+}
+
+const options: ThisTypedComponentOptionsWithRecordProps<
+  Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = {
+  created() {
+    this.canvas = process.browser
+  },
+  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    titleId: {
+      type: String,
+      default: ''
+    },
+    chartId: {
+      type: String,
+      default: 'scatter-chart'
+    },
+    chartData: {
+      type: Object,
+      required: false,
+      default: () => {
+        return {
+          datasets: [],
+          clusters: [],
+          labels: []
+        }
+      }
+    },
+    date: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    unit: {
+      type: String,
+      default: ''
+    },
+    info: {
+      type: Object,
+      default: () => {}
+    },
+    desc: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    url: {
+      type: String,
+      required: false,
+      default: ''
+    }
+  },
+  data: () => ({
+    dataKind: 'transition',
+    canvas: true
+  }),
+  computed: {
+    displayData() {
+      return {
+        labels: this.chartData.labels,
+        datasets: [
+          {
+            fill: false,
+            showLine: false,
+            data: this.chartData.datasets,
+            backgroundColor: color,
+            borderWidth: 0
+          }
+        ]
+      }
+    },
+    displayOption() {
+      const unit = this.unit
+      const data = this.chartData
+      const options = {
+        tooltips: {
+          displayColors: false,
+          callbacks: {
+            label(tooltipItem: any) {
+              return `${data.clusters[data.datasets[tooltipItem.index].y]} で ${
+                data.datasets[tooltipItem.index].label
+              } ${unit}`
+            },
+            title(tooltipItem: any) {
+              return data.datasets[tooltipItem[0].index].x
+            }
+          }
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+        legend: {
+          display: false
+        },
+        scales: {
+          xAxes: [
+            {
+              id: 'day',
+              stacked: true,
+              gridLines: {
+                display: false
+              },
+              ticks: {
+                fontSize: 9,
+                maxTicksLimit: 15,
+                fontColor: '#808080',
+                maxRotation: 0
+              },
+              type: 'time',
+              time: {
+                displayFormats: {
+                  day: 'D'
+                },
+                parser: 'M/D',
+                unit: 'day'
+              }
+            },
+            {
+              id: 'month',
+              stacked: true,
+              gridLines: {
+                drawOnChartArea: false,
+                drawTicks: true,
+                drawBorder: false,
+                tickMarkLength: 10
+              },
+              ticks: {
+                fontSize: 11,
+                fontColor: '#808080',
+                padding: 3,
+                fontStyle: 'bold',
+                gridLines: {
+                  display: true
+                }
+              },
+              type: 'time',
+              time: {
+                unit: 'month',
+                parser: 'M/D',
+                displayFormats: {
+                  month: 'MMM'
+                }
+              }
+            }
+          ],
+          yAxes: [
+            {
+              location: 'bottom',
+              stacked: true,
+              gridLines: {
+                display: true,
+                color: '#E5E5E5'
+              },
+              ticks: {
+                suggestedMin: 0,
+                maxTicksLimit: 12,
+                fontColor: '#808080',
+                max: data.clusters.length,
+                callback: (i: number) => {
+                  return data.clusters[i]
+                }
+              }
+            }
+          ]
+        }
+      }
+      if (this.$route.query.ogp === 'true') {
+        Object.assign(options, { animation: { duration: 0 } })
+      }
+      return options
+    },
+    tableHeaders() {
+      return TableHeader
+    },
+    tableData() {
+      const clusters = this.chartData.clusters
+      const data: TableDataType[] = []
+      clusters.forEach(dl => {
+        data.push({
+          クラスター: dl,
+          人数: 0
+        })
+      })
+      this.chartData.datasets.forEach(d => {
+        data[clusters.indexOf(clusters[d.y])]['人数'] += d.label
+      })
+      return data.reverse()
+    }
+  }
+}
+
+export default Vue.extend(options)
+</script>
+
+<style module lang="scss">
+.Graph {
+  &Desc {
+    width: 100%;
+    margin: 0;
+    margin-bottom: 0 !important;
+    padding-left: 0 !important;
+    font-size: 12px;
+    color: $gray-3;
+    list-style: none;
+  }
+  &Link {
+    text-decoration: none;
+  }
+}
+</style>

--- a/components/cards/PatientsByClusters.vue
+++ b/components/cards/PatientsByClusters.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
-    <data-table
+    <!--<data-table
       :title="$t('クラスター別陽性患者数')"
       :title-id="'patients-by-clusters'"
       :chart-data="clustersTable"
@@ -11,7 +11,7 @@
        'http://open-data.pref.hyogo.lg.jp/?page_id=141'
       "
       :desc="$t('（注）同一の対象者が複数含まれる場合あり')"
-    />
+    />-->
     <!--<time-bar-chart
       title="クラスター別陽性患者数"
       :title-id="'patients-by-clusters'"
@@ -27,47 +27,70 @@
       :horizontal="true"
       :overlap="patientsTable.datasets.length"
     />-->
+    <scatter
+      :title="$t('クラスター別陽性患者数')"
+      :title-id="'patients-by-clusters'"
+      :chart-id="'time-bar-chart-patients-by-clusters'"
+      :chart-data="clustersScatter"
+      :date="clusters.last_update"
+      :unit="'人'"
+      :info="sumInfoOfClusters"
+      :desc="$t('（注）同一の対象者が複数含まれる場合あり')"
+      :url="
+        'http://open-data.pref.hyogo.lg.jp/index.php?key=mu9jmny45-175#_175'
+      "
+    />
   </v-col>
 </template>
 
 <script>
-import clustersSummary from '@/data/clusters_summary.json'
+import clusters from '@/data/clusters.json'
+// import clustersSummary from '@/data/clusters_summary.json'
 import patientsSummary from '@/data/patients_summary.json'
-import DataTable from '@/components/DataTable.vue'
-import formatClustersTable from '@/utils/formatClustersTable'
+// import DataTable from '@/components/DataTable.vue'
+import Scatter from '@/components/Scatter'
+// import formatClustersTable from '@/utils/formatClustersTable'
 import formatGraph from '@/utils/formatGraph'
-import formatVariableGraph from '@/utils/formatVariableGraph'
+// import formatVariableGraph from '@/utils/formatVariableGraph'
+import formatClustersScatter from '@/utils/formatClustersScatter'
 
 export default {
   components: {
-    DataTable
+    // DataTable
+    Scatter
   },
   data() {
     // クラスター別陽性患者数
-    const clustersTable = formatClustersTable(clustersSummary.data)
-    const clustersGraph = formatVariableGraph(clustersSummary.data)
+    // const clustersTable = formatClustersTable(clustersSummary.data)
+    // const clustersGraph = formatVariableGraph(clustersSummary.data)
 
     // 感染者数グラフ 感染者数取得のため
     const patientsGraph = formatGraph(patientsSummary.data)
 
+    // 日別クラスター陽性患者数
+    const clustersScatter = formatClustersScatter(clusters.data)
+
+    let clusterTotal = 0
+    clustersScatter.datasets.forEach(d => {
+      clusterTotal += d.label
+    })
     const sumInfoOfClusters = {
-      lText: clustersGraph[
-        clustersGraph.length - 1
-      ].cumulative.toLocaleString(),
+      lText: clusterTotal.toLocaleString(),
       sText:
         this.$t('重複者') +
         ': ' +
         (
-          clustersGraph[clustersGraph.length - 1].cumulative -
-          patientsGraph[patientsGraph.length - 1].cumulative
+          clusterTotal - patientsGraph[patientsGraph.length - 1].cumulative
         ).toLocaleString() +
         this.$t('人'),
       unit: this.$t('人')
     }
 
     const data = {
-      clustersSummary,
-      clustersTable,
+      clusters,
+      // clustersSummary,
+      // clustersTable,
+      clustersScatter,
       sumInfoOfClusters
     }
     return data

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -1,6 +1,14 @@
 import Vue, { PropType } from 'vue'
 import { ChartData, ChartOptions } from 'chart.js'
-import { Doughnut, Pie, Bar, HorizontalBar, Line, mixins } from 'vue-chartjs'
+import {
+  Doughnut,
+  Pie,
+  Bar,
+  HorizontalBar,
+  Line,
+  Scatter,
+  mixins
+} from 'vue-chartjs'
 import { Plugin } from '@nuxt/types'
 import { useDayjsAdapter } from './chartjs-adapter-dayjs'
 
@@ -91,6 +99,24 @@ const createCustomChart = () => {
     'line-chart',
     {
       extends: Line,
+
+      mixins: [reactiveProp],
+      props: {
+        options: {
+          type: Object,
+          default: () => {}
+        }
+      },
+      mounted(): void {
+        this.renderChart(this.chartData, this.options)
+      }
+    }
+  )
+
+  Vue.component<ChartVCData, ChartVCMethod, ChartVCComputed, ChartVCProps>(
+    'scatter',
+    {
+      extends: Scatter,
 
       mixins: [reactiveProp],
       props: {

--- a/utils/formatClustersScatter.ts
+++ b/utils/formatClustersScatter.ts
@@ -1,0 +1,44 @@
+interface DataObject {
+  日付: string
+  [key: string]: number | string
+}
+
+export type ChildGraphDataType = {
+  x: string
+  y: number
+  label: number
+}
+
+export type GraphDataType = {
+  datasets: ChildGraphDataType[]
+  clusters: string[]
+  labels: string[]
+}
+
+export default (data: DataObject[]) => {
+  const clusters = Object.keys(data[0])
+    .reverse()
+    .filter(s => s !== '日付')
+  const graphData: GraphDataType = {
+    datasets: [],
+    clusters,
+    labels: []
+  }
+
+  data.forEach(d => {
+    const date = new Date(d['日付'])
+    const dateLable = `${date.getMonth() + 1}/${date.getDate()}`
+    graphData.labels.push(dateLable)
+    clusters.forEach((dl, j) => {
+      const patients = d[dl]
+      if (patients !== 0) {
+        graphData.datasets.push(<ChildGraphDataType>{
+          x: dateLable,
+          y: j,
+          label: patients
+        })
+      }
+    })
+  })
+  return graphData
+}

--- a/utils/formatClustersTable.ts
+++ b/utils/formatClustersTable.ts
@@ -1,4 +1,4 @@
-const headers = [
+export const headers = [
   { text: 'クラスター/感染源', value: 'クラスター' },
   { text: '人数', value: '人数' }
 ]
@@ -7,7 +7,7 @@ interface DataObject {
   [key: string]: number
 }
 
-type TableDataType = {
+export type TableDataType = {
   クラスター: string
   人数: number
 }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #169 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- クラスター別陽性患者数の表を散布図に切り替えることで経過表示が出来るように変更
- クラスターは高さを考えて最大12か所分表示できるようにしておきました(13以上になると一部が省略されます。)

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34832037/78472728-1cb9b400-7776-11ea-8e0f-e028d29d7e3d.png)
