### PR TITLE
fix table and logo size

### DIFF
--- a/components/CircleChart.vue
+++ b/components/CircleChart.vue
@@ -189,7 +189,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             data: this.chartData.map(d => {
               return d.transition
             }),
-            backgroundColor: this.chartData.map((d, index) => {
+            backgroundColor: this.chartData.map((_, index) => {
               return colors[index]
             }),
             borderWidth: 0
@@ -239,19 +239,18 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     tableHeaders() {
       return [
-        { text: '', value: 'text' },
         ...this.chartData.map((d, index) => {
           return { text: d.label, value: String(index) }
         })
       ]
     },
     tableData() {
-      return this.chartData.map((_, i) => {
-        return Object.assign(
-          { text: this.chartData[i].label },
-          { [i]: this.chartData[i].transition }
+      return [
+        Object.assign(
+          { '0': this.chartData[0].transition },
+          { '1': this.chartData[1].transition }
         )
-      })
+      ]
     }
   }
 }

--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -11,7 +11,7 @@
         }
       </style>
       <div class="noscript-heading">
-        <img src="/logo.svg" :alt="$t('兵庫県')" />
+        <img src="/logo.svg" :alt="$t('兵庫県')" width="110" />
         {{ $t('新型コロナウイルス') }}<br />{{ $t('まとめサイト') }}
       </div>
       <div class="noscript-body">


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #206 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- JavaScript無効化時に出る注意書きのロゴサイズをサイドバーのものと同じ大きさに修正
- 同じくJavaScript無効化時に出る表のうち、「入院患者数と残り病床数」がおかしかったのを修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34832037/78476114-4e834880-777f-11ea-9c89-de71aaf64e0e.png)
![image](https://user-images.githubusercontent.com/34832037/78476222-55aa5680-777f-11ea-94be-4b6efd5a7146.png)
