### PR TITLE
トップページのタイトルを修正

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -118,7 +118,8 @@ export default Vue.extend({
   },
   head(): MetaInfo {
     return {
-      title: this.$t('兵庫県内の最新感染動向') as string
+      title: this.$t('兵庫県非公式 新型コロナウイルスまとめサイト') as string,
+      titleTemplate: ''
     }
   }
 })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #221 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- トップページのtitleから「兵庫県内の最新感染動向 | 」を削除して，
「兵庫県非公式 新型コロナウイルスまとめサイト」のみに変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
