### PR TITLE
知事からのメッセージのリンクを更新

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -175,7 +175,8 @@ export default Vue.extend({
         },
         {
           title: this.$t('知事からのメッセージ'),
-          link: 'https://web.pref.hyogo.lg.jp/governor/g_comment20200321.html',
+          link:
+            'https://web.pref.hyogo.lg.jp/government/g_comment20200408.html',
           divider: true
         },
         /* {


### PR DESCRIPTION
#231   ⛏ 変更内容 / Details of Changes
リンク先を以下のとおり変更。
Before) https://web.pref.hyogo.lg.jp/governor/g_comment20200321.html
After) https://web.pref.hyogo.lg.jp/government/g_comment20200408.html