### PR TITLE
陽性患者の属性とクラスター別陽性患者数の人数計算を修正

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -30,9 +30,7 @@ export default {
     const patientsTable = formatTable(patients.data)
 
     const sumInfoOfPatients = {
-      lText: patientsGraph[
-        patientsGraph.length - 1
-      ].cumulative.toLocaleString(),
+      lText: patientsTable.datasets.length.toLocaleString(),
       sText: this.$t('{date}の累計', {
         date: patientsGraph[patientsGraph.length - 1].label
       }),

--- a/components/cards/PatientsByClusters.vue
+++ b/components/cards/PatientsByClusters.vue
@@ -46,11 +46,11 @@
 <script>
 import clusters from '@/data/clusters.json'
 // import clustersSummary from '@/data/clusters_summary.json'
-import patientsSummary from '@/data/patients_summary.json'
+import patients from '@/data/patients.json'
 // import DataTable from '@/components/DataTable.vue'
 import Scatter from '@/components/Scatter'
 // import formatClustersTable from '@/utils/formatClustersTable'
-import formatGraph from '@/utils/formatGraph'
+import formatTable from '@/utils/formatTable'
 // import formatVariableGraph from '@/utils/formatVariableGraph'
 import formatClustersScatter from '@/utils/formatClustersScatter'
 
@@ -64,8 +64,8 @@ export default {
     // const clustersTable = formatClustersTable(clustersSummary.data)
     // const clustersGraph = formatVariableGraph(clustersSummary.data)
 
-    // 感染者数グラフ 感染者数取得のため
-    const patientsGraph = formatGraph(patientsSummary.data)
+    // 感染者数
+    const patientsTable = formatTable(patients.data)
 
     // 日別クラスター陽性患者数
     const clustersScatter = formatClustersScatter(clusters.data)
@@ -79,9 +79,7 @@ export default {
       sText:
         this.$t('重複者') +
         ': ' +
-        (
-          clusterTotal - patientsGraph[patientsGraph.length - 1].cumulative
-        ).toLocaleString() +
+        (clusterTotal - patientsTable.datasets.length).toLocaleString() +
         this.$t('人'),
       unit: this.$t('人')
     }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
陽性患者の属性とクラスター別陽性患者数の人数計算が誤っていたので修正しました。

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 陽性患者の属性
    - 上部に表示する人数を表の件数に変更
- クラスター別陽性患者数
    - 重複人数の計算を「クラスターデータ数 - 陽性患者の属性の表の件数」に変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

<img width="1097" alt="スクリーンショット 2020-04-09 22 55 39" src="https://user-images.githubusercontent.com/2575204/78902839-47c54000-7ab5-11ea-9af8-46321898cbcb.png">
