### PR TITLE
#297 オープンデータカタログサイトの名称を正式なものに変更

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -49,7 +49,7 @@
             url="http://open-data.pref.hyogo.lg.jp/"
             :icon-size="16"
           >
-            {{ $t('兵庫県オープンデータカタログサイト') }}
+            {{ $t('ひょうごオープンデータカタログ') }}
           </external-link>
         </template>
       </i18n>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
close #297 
## 📝 関連する issue / Related Issues
## ⛏ 変更内容 / Details of Changes
- 「兵庫県オープンデータカタログサイト」となっていた物を「ひょうごオープンデータカタログ」に変更

## 📸 スクリーンショット / Screenshots
<img width="1151" alt="スクリーンショット 2020-04-29 16 06 54" src="https://user-images.githubusercontent.com/59169390/80571744-18607e00-8a38-11ea-8485-a65b23457fa9.png">
<img width="1151" alt="スクリーンショット 2020-04-29 16 06 58" src="https://user-images.githubusercontent.com/59169390/80571750-1a2a4180-8a38-11ea-8427-7890ca7e822d.png">
