### PR TITLE
aboutページ内の東京都のサイト名を正しいものに修正 #323

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -26,7 +26,7 @@
             url="https://stopcovid19.metro.tokyo.lg.jp/"
             :icon-size="16"
           >
-            {{ $t('東京都公式コロナウイルス対策サイト') }}
+            {{ $t('東京都公式新型コロナウイルス感染症対策サイト') }}
           </external-link>
         </template>
       </i18n>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #323 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- aboutページ内の東京都のサイト名を正しいものに修正。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2020-05-01 18 07 05](https://user-images.githubusercontent.com/59169390/80795145-a2464d80-8bd6-11ea-9cc0-f041cd6ff494.png)

