### PR TITLE
「治療中患者数の変化状況グラフ」の追加と「年代別陽性患者数」グラフの埋め込み時の問題の修正

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -414,10 +414,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayDataHeader() {
       if (this.dataKind === 'transition') {
         return {
-          labels: ['2020/1/1'],
+          labels: ['2020/1/1', '2020/1/2'],
           datasets: [
             {
-              data: [Math.max(...this.chartData.map(d => d.transition))],
+              data: [
+                Math.max(...this.chartData.map(d => d.transition)),
+                Math.min(...this.chartData.map(d => d.transition))
+              ],
               backgroundColor: 'transparent',
               borderWidth: 0
             }
@@ -425,10 +428,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         }
       }
       return {
-        labels: ['2020/1/1'],
+        labels: ['2020/1/1', '2020/1/2'],
         datasets: [
           {
-            data: [Math.max(...this.chartData.map(d => d.cumulative))],
+            data: [
+              Math.max(...this.chartData.map(d => d.cumulative)),
+              Math.min(...this.chartData.map(d => d.cumulative))
+            ],
             backgroundColor: 'transparent',
             borderWidth: 0
           }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -163,6 +163,7 @@ type Props = {
   showButton: boolean
   horizontal: boolean
   useScroll: boolean
+  defaultDataKind: String
   scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
 }
@@ -176,10 +177,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 > = {
   created() {
     this.canvas = process.browser
-    this.dataKind =
-      this.$route.query.embed && this.$route.query.dataKind === 'cumulative'
-        ? 'cumulative'
-        : 'transition'
+    if (this.defaultDataKind === 'cumulative') {
+      this.dataKind =
+        this.$route.query.embed && this.$route.query.dataKind === 'transition'
+          ? 'transition'
+          : 'cumulative'
+    } else {
+      this.dataKind =
+        this.$route.query.embed && this.$route.query.dataKind === 'cumulative'
+          ? 'cumulative'
+          : 'transition'
+    }
   },
   components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },
   props: {
@@ -230,6 +238,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: Boolean,
       required: false,
       default: true
+    },
+    defaultDataKind: {
+      type: String,
+      required: false,
+      default: 'transition'
     },
     scrollPlugin: {
       type: Array,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -442,7 +442,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
-      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
       const options: Chart.ChartOptions = {
         responsive: false,
         maintainAspectRatio: false,
@@ -519,8 +518,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
-                suggestedMax: scaledTicksYAxisMax
+                fontColor: '#808080' // #808080
               }
             }
           ]

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -177,16 +177,18 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 > = {
   created() {
     this.canvas = process.browser
-    if (this.defaultDataKind === 'cumulative') {
-      this.dataKind =
-        this.$route.query.embed && this.$route.query.dataKind === 'transition'
-          ? 'transition'
-          : 'cumulative'
-    } else {
-      this.dataKind =
-        this.$route.query.embed && this.$route.query.dataKind === 'cumulative'
-          ? 'cumulative'
-          : 'transition'
+    if (this.showButton) {
+      if (this.defaultDataKind === 'cumulative') {
+        this.dataKind =
+          this.$route.query.embed && this.$route.query.dataKind === 'transition'
+            ? 'transition'
+            : 'cumulative'
+      } else {
+        this.dataKind =
+          this.$route.query.embed && this.$route.query.dataKind === 'cumulative'
+            ? 'cumulative'
+            : 'transition'
+      }
     }
   },
   components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },

--- a/components/cards/ChangesPatientsNumberCard.vue
+++ b/components/cards/ChangesPatientsNumberCard.vue
@@ -13,6 +13,7 @@
           '（注）治療中患者数とは、陽性患者数から退院者数と死亡者数を除いた人数を指す'
         )
       "
+      :default-data-kind="'cumulative'"
     />
   </v-col>
 </template>

--- a/components/cards/ChangesPatientsNumberCard.vue
+++ b/components/cards/ChangesPatientsNumberCard.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-col cols="12" md="6" class="DataCard">
+    <time-bar-chart
+      :title="$t('治療中患者数の変化状況')"
+      :title-id="'changes-in-number-of-hospitalized-patients'"
+      :chart-id="'time-bar-chart-changes-patients'"
+      :chart-data="changesPatientsGraph"
+      :date="currentPatients.last_update"
+      :unit="$t('人')"
+      :url="'http://open-data.pref.hyogo.lg.jp/?page_id=141'"
+      :desc="
+        $t(
+          '（注）治療中患者数とは、陽性患者数から退院者数と死亡者数を除いた人数を指す'
+        )
+      "
+    />
+  </v-col>
+</template>
+
+<script>
+import currentPatients from '@/data/current_patients.json'
+import formatGraph from '@/utils/formatGraph'
+import TimeBarChart from '@/components/TimeBarChart.vue'
+
+export default {
+  components: {
+    TimeBarChart
+  },
+  data() {
+    // 治療中患者数の変化状況グラフ
+    const changesPatientsGraph = formatGraph(currentPatients.data)
+
+    const data = {
+      currentPatients,
+      changesPatientsGraph
+    }
+    return data
+  }
+}
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -185,8 +185,9 @@ const config: Configuration = {
         '/cards/predicted-number-of-toei-subway-passengers',
         '/cards/agency' */
         '/cards/patients-by-age',
-        '/cards/patients-by-clusters'
+        '/cards/patients-by-clusters',
         // '/cards/patients-and-sickbeds'
+        '/cards/change-in-number-of-hospitalized-patients'
       ]
 
       const routes: string[] = []

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -48,6 +48,11 @@
     <!-- <patients-and-sickbeds
       v-else-if="this.$route.params.card == 'patients-and-sickbeds'"
     /> -->
+    <changes-patients-number-card
+      v-else-if="
+        this.$route.params.card == 'changes-in-number-of-hospitalized-patients'
+      "
+    />
   </div>
 </template>
 
@@ -61,6 +66,7 @@ import inspectionsSummary from '@/data/inspections_summary.json'
 import age from '@/data/age.json'
 import clustersSummary from '@/data/clusters_summary.json'
 // import sickbedsSummary from '@/data/sickbeds_summary.json'
+import currentPatients from '@/data/current_patients.json'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 // import TestedCasesDetailsCard from '@/components/cards/TestedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
@@ -75,6 +81,7 @@ import AgencyCard from '@/components/cards/AgencyCard.vue' */
 import PatientsByAge from '@/components/cards/PatientsByAge.vue'
 import PatientsByClusters from '@/components/cards/PatientsByClusters.vue'
 // import PatientsAndSickbeds from '@/components/cards/PatientsAndSickbeds.vue'
+import ChangesPatientsNumberCard from '@/components/cards/ChangesPatientsNumberCard'
 import { convertISO8601FormatToDatetime } from '@/utils/formatDate'
 
 export default {
@@ -91,8 +98,9 @@ export default {
     MetroCard,
     AgencyCard */
     PatientsByAge,
-    PatientsByClusters
+    PatientsByClusters,
     // PatientsAndSickbeds
+    ChangesPatientsNumberCard
   },
   data() {
     let title, updatedAt
@@ -153,6 +161,10 @@ export default {
         title = this.$t('入院患者数と残り病床数')
         updatedAt = sickbedsSummary.last_update
         break */
+      case 'changes-in-number-of-hospitalized-patients':
+        title = this.$t('治療中患者数の変化状況')
+        updatedAt = currentPatients.last_update
+        break
     }
 
     const updatedTimeStr = convertISO8601FormatToDatetime(updatedAt)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -49,6 +49,8 @@
       <!--<patients-and-sickbeds />-->
       <!-- 都庁来庁者数の推移 -->
       <!--<agency-card />-->
+      <!-- 治療中患者数の変化状況 -->
+      <changes-patients-number-card />
     </card-row>
     <v-divider />
   </div>
@@ -77,6 +79,7 @@ import AgencyCard from '@/components/cards/AgencyCard.vue' */
 import PatientsByAge from '@/components/cards/PatientsByAge.vue'
 import PatientsByClusters from '@/components/cards/PatientsByClusters.vue'
 // import PatientsAndSickbeds from '@/components/cards/PatientsAndSickbeds.vue'
+import ChangesPatientsNumberCard from '@/components/cards/ChangesPatientsNumberCard.vue'
 import { convertISO8601FormatToDatetime } from '@/utils/formatDate'
 
 export default Vue.extend({
@@ -97,8 +100,9 @@ export default Vue.extend({
     MetroCard,
     AgencyCard, */
     PatientsByAge,
-    PatientsByClusters
+    PatientsByClusters,
     // PatientsAndSickbeds
+    ChangesPatientsNumberCard
   },
   data() {
     const updatedTimeStr = convertISO8601FormatToDatetime(

--- a/ui-test/ogp_screenshot.py
+++ b/ui-test/ogp_screenshot.py
@@ -23,8 +23,9 @@ PATHS = {
     #"/cards/shinjuku-st-heatmap": (959, 600),
     #"/cards/tokyo-st-heatmap": (959, 600)
     "/cards/patients-by-age": (959, 500),
-    "/cards/patients-by-clusters": (959, 500)
+    "/cards/patients-by-clusters": (959, 500),
     #"/cards/patients-and-sickbeds": (959, 500)
+    "/cards/changes-in-number-of-hospitalized-patients": (959, 500)
 }
 
 options = webdriver.ChromeOptions()


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #469 
- close #484 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- [北海道版のもの](https://stopcovid19.hokkaido.dev/cards/patients-summary?t=1589130766043)と同等のものを追加
- マイナス値が出ることによってy軸のメモリがずれる問題を修正
- カードの追加に当たってconfigやOGP周りを修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34832037/81505372-b18d6f80-9329-11ea-92a3-9053217e7d4a.png)
